### PR TITLE
Tried to fix map-level, row, column behaviour, added default intensity for monochromatic applications

### DIFF
--- a/neotrellis_monome_teensy/MonomeSerialDevice.h
+++ b/neotrellis_monome_teensy/MonomeSerialDevice.h
@@ -79,6 +79,7 @@ class MonomeSerialDevice : public MonomeEventQueue {
         uint8_t encoders;
         uint8_t gridX;
         uint8_t gridY;
+        uint8_t defaultIntensity;
 
         static const int variMonoThresh = 0;
         static const int MAXLEDCOUNT = 256;

--- a/neotrellis_monome_teensy/neotrellis_monome_teensy.ino
+++ b/neotrellis_monome_teensy/neotrellis_monome_teensy.ino
@@ -23,7 +23,7 @@
 
 // This assumes you are using a USB breakout board to route power to the board 
 // If you are plugging directly into the teensy, you will need to adjust this brightness to a much lower value
-#define BRIGHTNESS 255 // overall grid brightness - use gamma table below to adjust levels
+#define BRIGHTNESS 127 // overall grid brightness - use gamma table below to adjust levels
 
 #define R 255
 #define G 255


### PR DESCRIPTION
This works with using pyserialoscd, tested with "monome home.maxpat". Getting nice and smooth gradients across the device now.

It would be great if you could check it and see if it also works for you.