### PR TITLE
DONOTMERGE support for new serial msg to alter the tint

### DIFF
--- a/neotrellis_m4_monome/MonomeSerialDevice.cpp
+++ b/neotrellis_m4_monome/MonomeSerialDevice.cpp
@@ -56,7 +56,7 @@ void MonomeSerialDevice::setAllLEDs(int value) {
 }
 
 void MonomeSerialDevice::setGridLed(uint8_t x, uint8_t y, uint8_t level) {
-//    int index = x + (y * columns);   
+//    int index = x + (y * columns);
 //    if (index < MAXLEDCOUNT) leds[index] = level;
 
     if (x < columns && y < rows) {
@@ -65,7 +65,7 @@ void MonomeSerialDevice::setGridLed(uint8_t x, uint8_t y, uint8_t level) {
     }
     //debugfln(INFO, "LED index: %d x %d y %d", index, x, y);
 }
-        
+
 void MonomeSerialDevice::clearGridLed(uint8_t x, uint8_t y) {
     setGridLed(x, y, 0);
     //Serial.println("clearGridLed");
@@ -76,7 +76,7 @@ void MonomeSerialDevice::setArcLed(uint8_t enc, uint8_t led, uint8_t level) {
     if (index < MAXLEDCOUNT) leds[index] = level;
     //Serial.println("setArcLed");
 }
-        
+
 void MonomeSerialDevice::clearArcLed(uint8_t enc, uint8_t led) {
     setArcLed(enc, led, 0);
     //Serial.println("clearArcLed");
@@ -120,7 +120,7 @@ void MonomeSerialDevice::refresh() {
                 buf[ind++] = (leds[led] << 4) | leds[led + 1];
             }
         Serial.write(buf, 35);
-        
+
         ind = 3;
         buf[1] = 8;
         for (int y = 0; y < 8; y++)
@@ -129,7 +129,7 @@ void MonomeSerialDevice::refresh() {
                 buf[ind++] = (leds[led] << 4) | leds[led + 1];
             }
         Serial.write(buf, 35);
-        
+
         ind = 3;
         buf[1] = 0;
         buf[2] = 8;
@@ -148,7 +148,7 @@ void MonomeSerialDevice::refresh() {
                 buf[ind++] = (leds[led] << 4) | leds[led + 1];
             }
         Serial.write(buf, 35);
-        
+
         gridDirty = false;
     }
 
@@ -161,7 +161,7 @@ void MonomeSerialDevice::refresh() {
         for (led = 0; led < 64; led += 2)
             buf[ind++] = (leds[led] << 4) | leds[led + 1];
         Serial.write(buf, 34);
-        
+
         buf[1] = 1;
         ind = 2;
         for (led = 64; led < 128; led += 2)
@@ -173,13 +173,13 @@ void MonomeSerialDevice::refresh() {
         for (led = 128; led < 192; led += 2)
             buf[ind++] = (leds[led] << 4) | leds[led + 1];
         Serial.write(buf, 34);
-        
+
         buf[1] = 3;
         ind = 2;
         for (led = 192; led < 256; led += 2)
             buf[ind++] = (leds[led] << 4) | leds[led + 1];
         Serial.write(buf, 34);
-        
+
         buf[1] = 4;
         ind = 2;
         for (led = 256; led < 320; led += 2)
@@ -221,13 +221,13 @@ void MonomeSerialDevice::processSerial() {
     uint8_t gridX    = columns;          // Will be either 8 or 16
     uint8_t gridY    = rows;
     uint8_t numQuads = columns/rows;
-    
+
     // get command identifier: first byte of packet is identifier in the form: [(a << 4) + b]
     // a = section (ie. system, key-grid, digital, encoder, led grid, tilt)
     // b = command (ie. query, enable, led, key, frame)
 
-    identifierSent = Serial.read();  
-    
+    identifierSent = Serial.read();
+
     switch (identifierSent) {
         case 0x00:  // device information
         	// [null, "led-grid", "key-grid", "digital-out", "digital-in", "encoder", "analog-in", "analog-out", "tilt", "led-ring"]
@@ -268,7 +268,7 @@ void MonomeSerialDevice::processSerial() {
             //Serial.println("0x04");
             gridNum = Serial.read();        // grid number
             readX = Serial.read();          // x offset
-            readY = Serial.read();          // y offset 
+            readY = Serial.read();          // y offset
             break;
 
         case 0x05:
@@ -301,7 +301,7 @@ void MonomeSerialDevice::processSerial() {
 
 
       // 0x10-0x1F are for an LED Grid Control.  All bytes incoming, no responses back
-  
+
         case 0x10:            // /prefix/led/set x y [0/1]  / led off
           readX = Serial.read();
           readY = Serial.read();
@@ -333,13 +333,13 @@ void MonomeSerialDevice::processSerial() {
 
           for (y = 0; y < 8; y++) {               // each i will be a row
             intensity = Serial.read();            // read one byte of 8 bits on/off
-    
+
             for (x = 0; x < 8; x++) {             // for 8 LEDs on a row
               if ((intensity >> x) & 0x01) {      // if intensity bit set, light led full brightness
-                setGridLed(readX + x, readY + y, 15); 
+                setGridLed(readX + x, readY + y, 15);
               }
               else {
-                setGridLed(readX + x, readY + y, 0); 
+                setGridLed(readX + x, readY + y, 0);
               }
             }
           }
@@ -350,7 +350,7 @@ void MonomeSerialDevice::processSerial() {
           while (readX > 16) { readX += 16; }         // hacky shit to deal with negative numbers from rotation
           readX &= 0xF8;                              // floor the offset to 0 or 8
 
-          readY = Serial.read();                      // 
+          readY = Serial.read();                      //
           intensity = Serial.read();                  // read one byte of 8 bits on/off
 
           for (x = 0; x < 8; x++) {               // for the next 8 lights in row
@@ -393,34 +393,34 @@ void MonomeSerialDevice::processSerial() {
           readX = Serial.read();                      // led-grid / set LED intensity
           readY = Serial.read();                      // read the x and y coordinates
           intensity = Serial.read();                  // read the intensity
-          setGridLed(readX, readY, intensity);              
+          setGridLed(readX, readY, intensity);
           break;
 
         case 0x19:                               //  /prefix/led/level/all s
           intensity = Serial.read();                 // set all leds
-          setAllLEDs(intensity);              
+          setAllLEDs(intensity);
           break;
 
         case 0x1A:                               //   /prefix/led/level/map x y d[64]
-                                                 // set 8x8 block          
+                                                 // set 8x8 block
           readX = Serial.read();                      // x offset
           while (readX > 16) { readX += 16; }         // hacky shit to deal with negative numbers from rotation
           readX &= 0xF8;                              // floor the offset to 0 or 8
           readY = Serial.read();                      // y offset
           while (readY > 16) { readY += 16; }         // hacky shit to deal with negative numbers from rotation
           readY &= 0xF8;                              // floor the offset to 0 or 8
-          
+
           z = 0;
           for (y = 0; y < 8; y++) {
             for (x = 0; x < 8; x++) {
-              if (z % 2 == 0) {                    
+              if (z % 2 == 0) {
                 intensity = Serial.read();
                 if ( ((intensity >> 4) & 0x0F) > variMonoThresh) {  // even bytes, use upper nybble
                   setGridLed(readX + x, readY + y, (intensity >> 4) & 0x0F);
                 } else {
                   setGridLed(readX + x, readY + y, 0);
                 }
-              } else { 
+              } else {
                 if ((intensity & 0x0F) > variMonoThresh ) {      // odd bytes, use lower nybble
                   setGridLed(readX + x, readY + y, intensity & 0x0F);
                 } else {
@@ -446,7 +446,7 @@ void MonomeSerialDevice::processSerial() {
           while (readY > 16) { readY += 16; }         // hacky shit to deal with negative numbers from rotation
           readY &= 0xF8;                              // floor the offset to 0 or 8
           for (x = 0; x < 8; x++) {
-              if (x % 2 == 0) {                    
+              if (x % 2 == 0) {
                 intensity = Serial.read();
                 if ( (intensity >> 4 & 0x0F) > variMonoThresh) {  // even bytes, use upper nybble
                   setGridLed(readX + x, readY, (intensity >> 4) & 0x0F);
@@ -454,7 +454,7 @@ void MonomeSerialDevice::processSerial() {
                 else {
                   setGridLed(readX + x, readY, 0);
                 }
-              } else {                              
+              } else {
                 if ((intensity & 0x0F) > variMonoThresh ) {      // odd bytes, use lower nybble
                   setGridLed(readX + x, readY, intensity & 0x0F);
                 }
@@ -473,7 +473,7 @@ void MonomeSerialDevice::processSerial() {
           while (readY > 16) { readY += 16; }         // hacky shit to deal with negative numbers from rotation
           readY &= 0xF8;                              // floor the offset to 0 or 8
           for (y = 0; y < 8; y++) {
-              if (y % 2 == 0) {                    
+              if (y % 2 == 0) {
                 intensity = Serial.read();
                 if ( (intensity >> 4 & 0x0F) > variMonoThresh) {  // even bytes, use upper nybble
                   setGridLed(readX, readY + y, (intensity >> 4) & 0x0F);
@@ -481,7 +481,7 @@ void MonomeSerialDevice::processSerial() {
                 else {
                   setGridLed(readX, readY + y, 0);
                 }
-              } else {                              
+              } else {
                 if ((intensity & 0x0F) > variMonoThresh ) {      // odd bytes, use lower nybble
                   setGridLed(readX, readY + y, intensity & 0x0F);
                 }
@@ -515,7 +515,7 @@ void MonomeSerialDevice::processSerial() {
             Serial.print(" up - ");
             */
             break;
-            
+
         case 0x21:
             /*
              0x21 key-grid / key down
@@ -592,7 +592,7 @@ void MonomeSerialDevice::processSerial() {
         case 0x81:  //   tilt - 8 bytes [0x80, n, xh, xl, yh, yl, zh, zl]
             break;
 
-        // 0x90 variable 64 LED ring 
+        // 0x90 variable 64 LED ring
         case 0x90:
           //pattern:  /prefix/ring/set n x a
           //desc:   set led x of ring n to value a
@@ -604,9 +604,9 @@ void MonomeSerialDevice::processSerial() {
           readX = Serial.read();
           readA = Serial.read();
           //led_array[readN][readX] = readA;
-          setArcLed(readN, readX, readA);         
+          setArcLed(readN, readX, readA);
           break;
-     
+
         case 0x91:
           //pattern:  /prefix/ring/all n a
           //desc:   set all leds of ring n to a
@@ -620,7 +620,7 @@ void MonomeSerialDevice::processSerial() {
             //led_array[readN][q]=readA;
           }
           break;
-      
+
         case 0x92:
           //pattern:  /prefix/ring/map n d[32]
           //desc:   set leds of ring n to array d
@@ -635,17 +635,17 @@ void MonomeSerialDevice::processSerial() {
           //serial:   [0x92, n d[32]]
           readN = Serial.read();
           for (y = 0; y < 64; y++) {
-              if (y % 2 == 0) {                    
+              if (y % 2 == 0) {
                 intensity = Serial.read();
                 if ( (intensity >> 4 & 0x0F) > 0) {  // even bytes, use upper nybble
                   //led_array[readN][y] = (intensity >> 4 & 0x0F);
-                  setArcLed(readN, y, (intensity >> 4 & 0x0F)); 
+                  setArcLed(readN, y, (intensity >> 4 & 0x0F));
                 }
                 else {
                   //led_array[readN][y]=0;
-                  setArcLed(readN, y, 0);   
+                  setArcLed(readN, y, 0);
                 }
-              } else {                              
+              } else {
                 if ((intensity & 0x0F) > 0 ) {      // odd bytes, use lower nybble
                   //led_array[readN][y] = (intensity & 0x0F);
                   setArcLed(readN, y, (intensity & 0x0F));
@@ -671,7 +671,7 @@ void MonomeSerialDevice::processSerial() {
           readY = Serial.read();  // x2
           readA = Serial.read();
           //memset(led_array[readN],0,sizeof(led_array[readN]));
-      
+
           if (readX < readY){
             for (y = readX; y < readY; y++) {
               //led_array[readN][y] = readA;
@@ -688,11 +688,18 @@ void MonomeSerialDevice::processSerial() {
               setArcLed(readN, y, readA);
             }
           }
-          //note:   set range x1-x2 (inclusive) to a. wrapping supported, ie. set range 60,4 would set values 60,61,62,63,0,1,2,3,4. 
-          // always positive direction sweep. ie. 4,10 = 4,5,6,7,8,9,10 whereas 10,4 = 10,11,12,13...63,0,1,2,3,4 
+          //note:   set range x1-x2 (inclusive) to a. wrapping supported, ie. set range 60,4 would set values 60,61,62,63,0,1,2,3,4.
+          // always positive direction sweep. ie. 4,10 = 4,5,6,7,8,9,10 whereas 10,4 = 10,11,12,13...63,0,1,2,3,4
          break;
 
-        default: 
+        case 0xF9:
+            R = Serial.read();
+            G = Serial.read();
+            B = Serial.read();
+            colorDirty = true;
+         break;
+
+        default:
           break;
     }
 }
@@ -775,7 +782,7 @@ void MonomeEventQueue::sendArcKey(uint8_t index, uint8_t pressed) {
     Serial.write(buf, 2);
 }
 
-void MonomeEventQueue::sendGridKey(uint8_t x, uint8_t y, uint8_t pressed) {    
+void MonomeEventQueue::sendGridKey(uint8_t x, uint8_t y, uint8_t pressed) {
     uint8_t buf[2];
     if (pressed == 1){
       buf[0] = 0x21;

--- a/neotrellis_m4_monome/MonomeSerialDevice.h
+++ b/neotrellis_m4_monome/MonomeSerialDevice.h
@@ -19,7 +19,7 @@ class MonomeArcEvent {
 class MonomeEventQueue {
     public:
         //void clearQueue();
-        
+
         bool gridEventAvailable();
         MonomeGridEvent readGridEvent();
         MonomeGridEvent sendGridKey();
@@ -28,7 +28,7 @@ class MonomeEventQueue {
         MonomeArcEvent readArcEvent();
         MonomeArcEvent sendArcDelta();
         MonomeArcEvent sendArcKey();
-       
+
         void addGridEvent(uint8_t x, uint8_t y, uint8_t pressed);
         void sendGridKey(uint8_t x, uint8_t y, uint8_t pressed);
         void addArcEvent(uint8_t index, int8_t delta);
@@ -37,10 +37,10 @@ class MonomeEventQueue {
         void sendTiltEvent(uint8_t n,uint8_t xh,uint8_t xl, uint8_t yh,uint8_t yl, uint8_t zh,uint8_t zl);
 
     protected:
-        
+
     private:
         static const int MAXEVENTCOUNT = 50;
-        
+
         MonomeGridEvent emptyGridEvent;
         MonomeGridEvent gridEvents[MAXEVENTCOUNT];
         int gridEventCount = 0;
@@ -53,7 +53,7 @@ class MonomeEventQueue {
 };
 
 class MonomeSerialDevice : public MonomeEventQueue {
-    public: 
+    public:
         MonomeSerialDevice();
         void initialize();
         void setupAsGrid(uint8_t _rows, uint8_t _columns);
@@ -85,11 +85,16 @@ class MonomeSerialDevice : public MonomeEventQueue {
         static const int MAXLEDCOUNT = 256;
         uint8_t leds[MAXLEDCOUNT];
         String deviceID;
-        
-    private : 
+
+        uint8_t R = 255;
+        uint8_t G = 255;
+        uint8_t B = 255;
+        bool colorDirty = false;
+
+    private :
         bool arcDirty = false;
         bool gridDirty = false;
-        
+
 //        MonomeSerialDevice();
         void processSerial();
 };

--- a/neotrellis_monome_m0/MonomeSerialDevice.cpp
+++ b/neotrellis_monome_m0/MonomeSerialDevice.cpp
@@ -56,7 +56,7 @@ void MonomeSerialDevice::setAllLEDs(int value) {
 }
 
 void MonomeSerialDevice::setGridLed(uint8_t x, uint8_t y, uint8_t level) {
-//    int index = x + (y * columns);   
+//    int index = x + (y * columns);
 //    if (index < MAXLEDCOUNT) leds[index] = level;
 
     if (x < columns && y < rows) {
@@ -65,7 +65,7 @@ void MonomeSerialDevice::setGridLed(uint8_t x, uint8_t y, uint8_t level) {
     }
     //debugfln(INFO, "LED index: %d x %d y %d", index, x, y);
 }
-        
+
 void MonomeSerialDevice::clearGridLed(uint8_t x, uint8_t y) {
     setGridLed(x, y, 0);
     //Serial.println("clearGridLed");
@@ -76,7 +76,7 @@ void MonomeSerialDevice::setArcLed(uint8_t enc, uint8_t led, uint8_t level) {
     if (index < MAXLEDCOUNT) leds[index] = level;
     //Serial.println("setArcLed");
 }
-        
+
 void MonomeSerialDevice::clearArcLed(uint8_t enc, uint8_t led) {
     setArcLed(enc, led, 0);
     //Serial.println("clearArcLed");
@@ -120,7 +120,7 @@ void MonomeSerialDevice::refresh() {
                 buf[ind++] = (leds[led] << 4) | leds[led + 1];
             }
         Serial.write(buf, 35);
-        
+
         ind = 3;
         buf[1] = 8;
         for (int y = 0; y < 8; y++)
@@ -129,7 +129,7 @@ void MonomeSerialDevice::refresh() {
                 buf[ind++] = (leds[led] << 4) | leds[led + 1];
             }
         Serial.write(buf, 35);
-        
+
         ind = 3;
         buf[1] = 0;
         buf[2] = 8;
@@ -148,7 +148,7 @@ void MonomeSerialDevice::refresh() {
                 buf[ind++] = (leds[led] << 4) | leds[led + 1];
             }
         Serial.write(buf, 35);
-        
+
         gridDirty = false;
     }
 
@@ -161,7 +161,7 @@ void MonomeSerialDevice::refresh() {
         for (led = 0; led < 64; led += 2)
             buf[ind++] = (leds[led] << 4) | leds[led + 1];
         Serial.write(buf, 34);
-        
+
         buf[1] = 1;
         ind = 2;
         for (led = 64; led < 128; led += 2)
@@ -173,13 +173,13 @@ void MonomeSerialDevice::refresh() {
         for (led = 128; led < 192; led += 2)
             buf[ind++] = (leds[led] << 4) | leds[led + 1];
         Serial.write(buf, 34);
-        
+
         buf[1] = 3;
         ind = 2;
         for (led = 192; led < 256; led += 2)
             buf[ind++] = (leds[led] << 4) | leds[led + 1];
         Serial.write(buf, 34);
-        
+
         buf[1] = 4;
         ind = 2;
         for (led = 256; led < 320; led += 2)
@@ -221,13 +221,13 @@ void MonomeSerialDevice::processSerial() {
     uint8_t gridX    = columns;          // Will be either 8 or 16
     uint8_t gridY    = rows;
     uint8_t numQuads = columns/rows;
-    
+
     // get command identifier: first byte of packet is identifier in the form: [(a << 4) + b]
     // a = section (ie. system, key-grid, digital, encoder, led grid, tilt)
     // b = command (ie. query, enable, led, key, frame)
 
-    identifierSent = Serial.read();  
-    
+    identifierSent = Serial.read();
+
     switch (identifierSent) {
         case 0x00:  // device information
         	// [null, "led-grid", "key-grid", "digital-out", "digital-in", "encoder", "analog-in", "analog-out", "tilt", "led-ring"]
@@ -237,8 +237,8 @@ void MonomeSerialDevice::processSerial() {
             Serial.write((uint8_t)numQuads);   // one Quad is 64 buttons
 
             Serial.write((uint8_t)0x00); // send again with 2 = key-grid
-            Serial.write((uint8_t)0x02); // 
-            Serial.write((uint8_t)numQuads); 
+            Serial.write((uint8_t)0x02); //
+            Serial.write((uint8_t)numQuads);
 
             break;
 
@@ -272,7 +272,7 @@ void MonomeSerialDevice::processSerial() {
             //Serial.println("0x04");
             gridNum = Serial.read();        // grid number
             readX = Serial.read();          // x offset
-            readY = Serial.read();          // y offset 
+            readY = Serial.read();          // y offset
             break;
 
         case 0x05:  // _SYS_GET_GRID_SIZE
@@ -305,7 +305,7 @@ void MonomeSerialDevice::processSerial() {
 
 
       // 0x10-0x1F are for an LED Grid Control.  All bytes incoming, no responses back
-  
+
         case 0x10:            // /prefix/led/set x y [0/1]  / led off
           readX = Serial.read();
           readY = Serial.read();
@@ -337,13 +337,13 @@ void MonomeSerialDevice::processSerial() {
 
           for (y = 0; y < 8; y++) {               // each i will be a row
             intensity = Serial.read();            // read one byte of 8 bits on/off
-    
+
             for (x = 0; x < 8; x++) {             // for 8 LEDs on a row
               if ((intensity >> x) & 0x01) {      // if intensity bit set, light led full brightness
-                setGridLed(readX + x, readY + y, 15); 
+                setGridLed(readX + x, readY + y, 15);
               }
               else {
-                setGridLed(readX + x, readY + y, 0); 
+                setGridLed(readX + x, readY + y, 0);
               }
             }
           }
@@ -354,7 +354,7 @@ void MonomeSerialDevice::processSerial() {
           while (readX > 16) { readX += 16; }         // hacky shit to deal with negative numbers from rotation
           readX &= 0xF8;                              // floor the offset to 0 or 8
 
-          readY = Serial.read();                      // 
+          readY = Serial.read();                      //
           intensity = Serial.read();                  // read one byte of 8 bits on/off
 
           for (x = 0; x < 8; x++) {               // for the next 8 lights in row
@@ -397,34 +397,34 @@ void MonomeSerialDevice::processSerial() {
           readX = Serial.read();                      // led-grid / set LED intensity
           readY = Serial.read();                      // read the x and y coordinates
           intensity = Serial.read();                  // read the intensity
-          setGridLed(readX, readY, intensity);              
+          setGridLed(readX, readY, intensity);
           break;
 
         case 0x19:                               //  /prefix/led/level/all s
           intensity = Serial.read();                 // set all leds
-          setAllLEDs(intensity);              
+          setAllLEDs(intensity);
           break;
 
         case 0x1A:                               //   /prefix/led/level/map x y d[64]
-                                                 // set 8x8 block          
+                                                 // set 8x8 block
           readX = Serial.read();                      // x offset
           while (readX > 16) { readX += 16; }         // hacky shit to deal with negative numbers from rotation
           readX &= 0xF8;                              // floor the offset to 0 or 8
           readY = Serial.read();                      // y offset
           while (readY > 16) { readY += 16; }         // hacky shit to deal with negative numbers from rotation
           readY &= 0xF8;                              // floor the offset to 0 or 8
-          
+
           z = 0;
           for (y = 0; y < 8; y++) {
             for (x = 0; x < 8; x++) {
-              if (z % 2 == 0) {                    
+              if (z % 2 == 0) {
                 intensity = Serial.read();
                 if ( ((intensity >> 4) & 0x0F) > variMonoThresh) {  // even bytes, use upper nybble
                   setGridLed(readX + x, readY + y, (intensity >> 4) & 0x0F);
                 } else {
                   setGridLed(readX + x, readY + y, 0);
                 }
-              } else { 
+              } else {
                 if ((intensity & 0x0F) > variMonoThresh ) {      // odd bytes, use lower nybble
                   setGridLed(readX + x, readY + y, intensity & 0x0F);
                 } else {
@@ -450,7 +450,7 @@ void MonomeSerialDevice::processSerial() {
           while (readY > 16) { readY += 16; }         // hacky shit to deal with negative numbers from rotation
           readY &= 0xF8;                              // floor the offset to 0 or 8
           for (x = 0; x < 8; x++) {
-              if (x % 2 == 0) {                    
+              if (x % 2 == 0) {
                 intensity = Serial.read();
                 if ( (intensity >> 4 & 0x0F) > variMonoThresh) {  // even bytes, use upper nybble
                   setGridLed(readX + x, readY, (intensity >> 4) & 0x0F);
@@ -458,7 +458,7 @@ void MonomeSerialDevice::processSerial() {
                 else {
                   setGridLed(readX + x, readY, 0);
                 }
-              } else {                              
+              } else {
                 if ((intensity & 0x0F) > variMonoThresh ) {      // odd bytes, use lower nybble
                   setGridLed(readX + x, readY, intensity & 0x0F);
                 }
@@ -477,7 +477,7 @@ void MonomeSerialDevice::processSerial() {
           while (readY > 16) { readY += 16; }         // hacky shit to deal with negative numbers from rotation
           readY &= 0xF8;                              // floor the offset to 0 or 8
           for (y = 0; y < 8; y++) {
-              if (y % 2 == 0) {                    
+              if (y % 2 == 0) {
                 intensity = Serial.read();
                 if ( (intensity >> 4 & 0x0F) > variMonoThresh) {  // even bytes, use upper nybble
                   setGridLed(readX, readY + y, (intensity >> 4) & 0x0F);
@@ -485,7 +485,7 @@ void MonomeSerialDevice::processSerial() {
                 else {
                   setGridLed(readX, readY + y, 0);
                 }
-              } else {                              
+              } else {
                 if ((intensity & 0x0F) > variMonoThresh ) {      // odd bytes, use lower nybble
                   setGridLed(readX, readY + y, intensity & 0x0F);
                 }
@@ -519,7 +519,7 @@ void MonomeSerialDevice::processSerial() {
             Serial.print(" up - ");
             */
             break;
-            
+
         case 0x21:
             /*
              0x21 key-grid / key down
@@ -596,7 +596,7 @@ void MonomeSerialDevice::processSerial() {
         case 0x81:  //   tilt - 8 bytes [0x80, n, xh, xl, yh, yl, zh, zl]
             break;
 
-        // 0x90 variable 64 LED ring 
+        // 0x90 variable 64 LED ring
         case 0x90:
           //pattern:  /prefix/ring/set n x a
           //desc:   set led x of ring n to value a
@@ -608,9 +608,9 @@ void MonomeSerialDevice::processSerial() {
           readX = Serial.read();
           readA = Serial.read();
           //led_array[readN][readX] = readA;
-          setArcLed(readN, readX, readA);         
+          setArcLed(readN, readX, readA);
           break;
-     
+
         case 0x91:
           //pattern:  /prefix/ring/all n a
           //desc:   set all leds of ring n to a
@@ -624,7 +624,7 @@ void MonomeSerialDevice::processSerial() {
             //led_array[readN][q]=readA;
           }
           break;
-      
+
         case 0x92:
           //pattern:  /prefix/ring/map n d[32]
           //desc:   set leds of ring n to array d
@@ -639,17 +639,17 @@ void MonomeSerialDevice::processSerial() {
           //serial:   [0x92, n d[32]]
           readN = Serial.read();
           for (y = 0; y < 64; y++) {
-              if (y % 2 == 0) {                    
+              if (y % 2 == 0) {
                 intensity = Serial.read();
                 if ( (intensity >> 4 & 0x0F) > 0) {  // even bytes, use upper nybble
                   //led_array[readN][y] = (intensity >> 4 & 0x0F);
-                  setArcLed(readN, y, (intensity >> 4 & 0x0F)); 
+                  setArcLed(readN, y, (intensity >> 4 & 0x0F));
                 }
                 else {
                   //led_array[readN][y]=0;
-                  setArcLed(readN, y, 0);   
+                  setArcLed(readN, y, 0);
                 }
-              } else {                              
+              } else {
                 if ((intensity & 0x0F) > 0 ) {      // odd bytes, use lower nybble
                   //led_array[readN][y] = (intensity & 0x0F);
                   setArcLed(readN, y, (intensity & 0x0F));
@@ -675,7 +675,7 @@ void MonomeSerialDevice::processSerial() {
           readY = Serial.read();  // x2
           readA = Serial.read();
           //memset(led_array[readN],0,sizeof(led_array[readN]));
-      
+
           if (readX < readY){
             for (y = readX; y < readY; y++) {
               //led_array[readN][y] = readA;
@@ -692,11 +692,18 @@ void MonomeSerialDevice::processSerial() {
               setArcLed(readN, y, readA);
             }
           }
-          //note:   set range x1-x2 (inclusive) to a. wrapping supported, ie. set range 60,4 would set values 60,61,62,63,0,1,2,3,4. 
-          // always positive direction sweep. ie. 4,10 = 4,5,6,7,8,9,10 whereas 10,4 = 10,11,12,13...63,0,1,2,3,4 
+          //note:   set range x1-x2 (inclusive) to a. wrapping supported, ie. set range 60,4 would set values 60,61,62,63,0,1,2,3,4.
+          // always positive direction sweep. ie. 4,10 = 4,5,6,7,8,9,10 whereas 10,4 = 10,11,12,13...63,0,1,2,3,4
          break;
 
-        default: 
+        case 0xF9:
+            R = Serial.read();
+            G = Serial.read();
+            B = Serial.read();
+            colorDirty = true;
+         break;
+
+        default:
           break;
     }
 }
@@ -779,7 +786,7 @@ void MonomeEventQueue::sendArcKey(uint8_t index, uint8_t pressed) {
     Serial.write(buf, 2);
 }
 
-void MonomeEventQueue::sendGridKey(uint8_t x, uint8_t y, uint8_t pressed) {    
+void MonomeEventQueue::sendGridKey(uint8_t x, uint8_t y, uint8_t pressed) {
     uint8_t buf[2];
     if (pressed == 1){
       buf[0] = 0x21;

--- a/neotrellis_monome_m0/MonomeSerialDevice.h
+++ b/neotrellis_monome_m0/MonomeSerialDevice.h
@@ -19,7 +19,7 @@ class MonomeArcEvent {
 class MonomeEventQueue {
     public:
         //void clearQueue();
-        
+
         bool gridEventAvailable();
         MonomeGridEvent readGridEvent();
         MonomeGridEvent sendGridKey();
@@ -28,7 +28,7 @@ class MonomeEventQueue {
         MonomeArcEvent readArcEvent();
         MonomeArcEvent sendArcDelta();
         MonomeArcEvent sendArcKey();
-       
+
         void addGridEvent(uint8_t x, uint8_t y, uint8_t pressed);
         void sendGridKey(uint8_t x, uint8_t y, uint8_t pressed);
         void addArcEvent(uint8_t index, int8_t delta);
@@ -37,10 +37,10 @@ class MonomeEventQueue {
         void sendTiltEvent(uint8_t n,uint8_t xh,uint8_t xl, uint8_t yh,uint8_t yl, uint8_t zh,uint8_t zl);
 
     protected:
-        
+
     private:
         static const int MAXEVENTCOUNT = 50;
-        
+
         MonomeGridEvent emptyGridEvent;
         MonomeGridEvent gridEvents[MAXEVENTCOUNT];
         int gridEventCount = 0;
@@ -53,7 +53,7 @@ class MonomeEventQueue {
 };
 
 class MonomeSerialDevice : public MonomeEventQueue {
-    public: 
+    public:
         MonomeSerialDevice();
         void initialize();
         void setupAsGrid(uint8_t _rows, uint8_t _columns);
@@ -85,11 +85,16 @@ class MonomeSerialDevice : public MonomeEventQueue {
         static const int MAXLEDCOUNT = 256;
         uint8_t leds[MAXLEDCOUNT];
         String deviceID;
-        
-    private : 
+
+        uint8_t R = 255;
+        uint8_t G = 255;
+        uint8_t B = 255;
+        bool colorDirty = false;
+
+    private :
         bool arcDirty = false;
         bool gridDirty = false;
-        
+
 //        MonomeSerialDevice();
         void processSerial();
 };

--- a/neotrellis_monome_m0/neotrellis_monome_m0.ino
+++ b/neotrellis_monome_m0/neotrellis_monome_m0.ino
@@ -1,16 +1,16 @@
 /***********************************************************
  *  DIY monome compatible grid w/ Adafruit NeoTrellis
  *  for Feather M0 / M4
- *  
+ *
  *  This code makes the Adafruit Neotrellis boards into a Monome compatible grid via monome's mext protocol
  *  ----> https://www.adafruit.com/product/3954
- *  
+ *
  *  Code here is for a 16x8 grid, but can be modified for 4x8, 8x8, or 16x16 (untested on larger grid arrays)
- *  
- *  Many thanks to: 
- *  scanner_darkly <https://github.com/scanner-darkly>, 
- *  TheKitty <https://github.com/TheKitty>, 
- *  Szymon Kaliski <https://github.com/szymonkaliski>, 
+ *
+ *  Many thanks to:
+ *  scanner_darkly <https://github.com/scanner-darkly>,
+ *  TheKitty <https://github.com/TheKitty>,
+ *  Szymon Kaliski <https://github.com/szymonkaliski>,
  *  John Park, Todbot, Juanma, Gerald Stevens, and others
  *
 */
@@ -35,16 +35,16 @@
 #define INT_PIN 9
 #define LED_PIN 13 // teensy LED used to show boot info
 
-// This assumes you are using a USB breakout board to route power to the board 
+// This assumes you are using a USB breakout board to route power to the board
 // If you are plugging directly into the controller, you will need to adjust this brightness to a much lower value
 #define BRIGHTNESS 255 // overall grid brightness - use gamma table below to adjust levels
 
-#define R 255
-#define G 255
-#define B 255
+#define DEFAULT_R 255
+#define DEFAULT_G 255
+#define DEFAULT_B 255
 
 // gamma table for 16 levels of brightness
-const uint8_t gammaTable[16] = { 0,  2,  3,  6,  11, 18, 25, 32, 41, 59, 70, 80, 92, 103, 115, 128}; 
+const uint8_t gammaTable[16] = { 0,  2,  3,  6,  11, 18, 25, 32, 41, 59, 70, 80, 92, 103, 115, 128};
 
 
 bool isInited = false;
@@ -54,7 +54,7 @@ elapsedMillis monomeRefresh;
 String deviceID = "neo-monome";
 String serialNum = "m4216124";
 
-// DEVICE INFO FOR ADAFRUIT M0 or M4 
+// DEVICE INFO FOR ADAFRUIT M0 or M4
 char mfgstr[32] = "monome";
 char prodstr[32] = "monome";
 char serialstr[32] = "m4216124";
@@ -62,7 +62,7 @@ char serialstr[32] = "m4216124";
 // Monome class setup
 MonomeSerialDevice mdp;
 
-int prevLedBuffer[mdp.MAXLEDCOUNT]; 
+int prevLedBuffer[mdp.MAXLEDCOUNT];
 
 
 // NeoTrellis setup
@@ -73,7 +73,7 @@ Adafruit_NeoTrellis trellis_array[NUM_ROWS / 4][NUM_COLS / 4] = {
   { Adafruit_NeoTrellis(0x32), Adafruit_NeoTrellis(0x30) }
 };
 */
-// 16x8 
+// 16x8
 Adafruit_NeoTrellis trellis_array[NUM_ROWS / 4][NUM_COLS / 4] = {
   { Adafruit_NeoTrellis(0x32), Adafruit_NeoTrellis(0x30), Adafruit_NeoTrellis(0x2F), Adafruit_NeoTrellis(0x2E)}, // top row
   { Adafruit_NeoTrellis(0x33), Adafruit_NeoTrellis(0x31), Adafruit_NeoTrellis(0x3E), Adafruit_NeoTrellis(0x36) } // bottom row
@@ -110,14 +110,14 @@ uint32_t Wheel(byte WheelPos) {
 }
 
 // ***************************************************************************
-// **                          FUNCTIONS FOR TRELLIS                        **   
+// **                          FUNCTIONS FOR TRELLIS                        **
 // ***************************************************************************
 
 
 //define a callback for key presses
 TrellisCallback keyCallback(keyEvent evt){
   uint8_t x  = evt.bit.NUM % NUM_COLS;
-  uint8_t y = evt.bit.NUM / NUM_COLS; 
+  uint8_t y = evt.bit.NUM / NUM_COLS;
 
   if(evt.bit.EDGE == SEESAW_KEYPAD_EDGE_RISING){
     //Serial.println(" pressed ");
@@ -146,14 +146,17 @@ void setup(){
 	USBDevice.setManufacturerDescriptor(mfgstr);
 	USBDevice.setProductDescriptor(prodstr);
   USBDevice.setSerialDescriptor(serialstr);
-  
+
   Serial.begin(115200);
-  
+
 	mdp.isMonome = true;
 	mdp.deviceID = deviceID;
 	mdp.setupAsGrid(NUM_ROWS, NUM_COLS);
-  	monomeRefresh = 0;
-  	isInited = true;
+  mdp.R = DEFAULT_R;
+  mdp.G = DEFAULT_G;
+  mdp.B = DEFAULT_B;
+  monomeRefresh = 0;
+  isInited = true;
 
 	int var = 0;
 	while (var < 8) {
@@ -188,7 +191,7 @@ void setup(){
 	// clear grid leds
 	mdp.setAllLEDs(0);
 	sendLeds();
-	
+
     // blink one led to show it's started up
   	for(int i=0; i< NUM_ROWS * NUM_COLS; i++){
 		 trellis.setPixelColor(i, 0xFFFFFF);
@@ -210,15 +213,15 @@ void sendLeds(){
   uint8_t value, prevValue = 0;
   uint32_t hexColor;
   bool isDirty = false;
-  
+
   for(int i=0; i< NUM_ROWS * NUM_COLS; i++){
     value = mdp.leds[i];
     prevValue = prevLedBuffer[i];
     uint8_t gvalue = gammaTable[value];
-    
-    if (value != prevValue) {
-      //hexColor = (((R * value) >> 4) << 16) + (((G * value) >> 4) << 8) + ((B * value) >> 4); 
-      hexColor =  (((gvalue*R)/256) << 16) + (((gvalue*G)/256) << 8) + (((gvalue*B)/256) << 0);
+
+    if (value != prevValue || mdp.colorDirty) {
+      //hexColor = (((mdp.R * value) >> 4) << 16) + (((mdp.G * value) >> 4) << 8) + ((mdp.B * value) >> 4);
+      hexColor =  (((gvalue*mdp.R)/256) << 16) + (((gvalue*mdp.G)/256) << 8) + (((gvalue*mdp.B)/256) << 0);
       trellis.setPixelColor(i, hexColor);
 
       prevLedBuffer[i] = value;
@@ -227,6 +230,7 @@ void sendLeds(){
   }
   if (isDirty) {
     trellis.show();
+    mdp.colorDirty = false;
   }
 
 }
@@ -240,7 +244,7 @@ void sendLeds(){
 void loop() {
 
     mdp.poll(); // process incoming serial from Monomes
- 
+
     // refresh every 16ms or so
     if (isInited && monomeRefresh > 16) {
         trellis.read();

--- a/neotrellis_monome_rp2040/MonomeSerialDevice.cpp
+++ b/neotrellis_monome_rp2040/MonomeSerialDevice.cpp
@@ -56,7 +56,7 @@ void MonomeSerialDevice::setAllLEDs(int value) {
 }
 
 void MonomeSerialDevice::setGridLed(uint8_t x, uint8_t y, uint8_t level) {
-//    int index = x + (y * columns);   
+//    int index = x + (y * columns);
 //    if (index < MAXLEDCOUNT) leds[index] = level;
 
     if (x < columns && y < rows) {
@@ -65,7 +65,7 @@ void MonomeSerialDevice::setGridLed(uint8_t x, uint8_t y, uint8_t level) {
     }
     //debugfln(INFO, "LED index: %d x %d y %d", index, x, y);
 }
-        
+
 void MonomeSerialDevice::clearGridLed(uint8_t x, uint8_t y) {
     setGridLed(x, y, 0);
     //Serial.println("clearGridLed");
@@ -76,7 +76,7 @@ void MonomeSerialDevice::setArcLed(uint8_t enc, uint8_t led, uint8_t level) {
     if (index < MAXLEDCOUNT) leds[index] = level;
     //Serial.println("setArcLed");
 }
-        
+
 void MonomeSerialDevice::clearArcLed(uint8_t enc, uint8_t led) {
     setArcLed(enc, led, 0);
     //Serial.println("clearArcLed");
@@ -120,7 +120,7 @@ void MonomeSerialDevice::refresh() {
                 buf[ind++] = (leds[led] << 4) | leds[led + 1];
             }
         Serial.write(buf, 35);
-        
+
         ind = 3;
         buf[1] = 8;
         for (int y = 0; y < 8; y++)
@@ -129,7 +129,7 @@ void MonomeSerialDevice::refresh() {
                 buf[ind++] = (leds[led] << 4) | leds[led + 1];
             }
         Serial.write(buf, 35);
-        
+
         ind = 3;
         buf[1] = 0;
         buf[2] = 8;
@@ -148,7 +148,7 @@ void MonomeSerialDevice::refresh() {
                 buf[ind++] = (leds[led] << 4) | leds[led + 1];
             }
         Serial.write(buf, 35);
-        
+
         gridDirty = false;
     }
 
@@ -161,7 +161,7 @@ void MonomeSerialDevice::refresh() {
         for (led = 0; led < 64; led += 2)
             buf[ind++] = (leds[led] << 4) | leds[led + 1];
         Serial.write(buf, 34);
-        
+
         buf[1] = 1;
         ind = 2;
         for (led = 64; led < 128; led += 2)
@@ -173,13 +173,13 @@ void MonomeSerialDevice::refresh() {
         for (led = 128; led < 192; led += 2)
             buf[ind++] = (leds[led] << 4) | leds[led + 1];
         Serial.write(buf, 34);
-        
+
         buf[1] = 3;
         ind = 2;
         for (led = 192; led < 256; led += 2)
             buf[ind++] = (leds[led] << 4) | leds[led + 1];
         Serial.write(buf, 34);
-        
+
         buf[1] = 4;
         ind = 2;
         for (led = 256; led < 320; led += 2)
@@ -221,13 +221,13 @@ void MonomeSerialDevice::processSerial() {
     uint8_t gridX    = columns;          // Will be either 8 or 16
     uint8_t gridY    = rows;
     uint8_t numQuads = columns/rows;
-    
+
     // get command identifier: first byte of packet is identifier in the form: [(a << 4) + b]
     // a = section (ie. system, key-grid, digital, encoder, led grid, tilt)
     // b = command (ie. query, enable, led, key, frame)
 
-    identifierSent = Serial.read();  
-    
+    identifierSent = Serial.read();
+
     switch (identifierSent) {
         case 0x00:  // device information
         	// [null, "led-grid", "key-grid", "digital-out", "digital-in", "encoder", "analog-in", "analog-out", "tilt", "led-ring"]
@@ -237,8 +237,8 @@ void MonomeSerialDevice::processSerial() {
             Serial.write((uint8_t)numQuads);   // one Quad is 64 buttons
 
             Serial.write((uint8_t)0x00); // send again with 2 = key-grid
-            Serial.write((uint8_t)0x02); // 
-            Serial.write((uint8_t)numQuads); 
+            Serial.write((uint8_t)0x02); //
+            Serial.write((uint8_t)numQuads);
 
             break;
 
@@ -272,7 +272,7 @@ void MonomeSerialDevice::processSerial() {
             //Serial.println("0x04");
             gridNum = Serial.read();        // grid number
             readX = Serial.read();          // x offset
-            readY = Serial.read();          // y offset 
+            readY = Serial.read();          // y offset
             break;
 
         case 0x05:  // _SYS_GET_GRID_SIZE
@@ -305,7 +305,7 @@ void MonomeSerialDevice::processSerial() {
 
 
       // 0x10-0x1F are for an LED Grid Control.  All bytes incoming, no responses back
-  
+
         case 0x10:            // /prefix/led/set x y [0/1]  / led off
           readX = Serial.read();
           readY = Serial.read();
@@ -337,13 +337,13 @@ void MonomeSerialDevice::processSerial() {
 
           for (y = 0; y < 8; y++) {               // each i will be a row
             intensity = Serial.read();            // read one byte of 8 bits on/off
-    
+
             for (x = 0; x < 8; x++) {             // for 8 LEDs on a row
               if ((intensity >> x) & 0x01) {      // if intensity bit set, light led full brightness
-                setGridLed(readX + x, readY + y, 15); 
+                setGridLed(readX + x, readY + y, 15);
               }
               else {
-                setGridLed(readX + x, readY + y, 0); 
+                setGridLed(readX + x, readY + y, 0);
               }
             }
           }
@@ -354,7 +354,7 @@ void MonomeSerialDevice::processSerial() {
           while (readX > 16) { readX += 16; }         // hacky shit to deal with negative numbers from rotation
           readX &= 0xF8;                              // floor the offset to 0 or 8
 
-          readY = Serial.read();                      // 
+          readY = Serial.read();                      //
           intensity = Serial.read();                  // read one byte of 8 bits on/off
 
           for (x = 0; x < 8; x++) {               // for the next 8 lights in row
@@ -397,34 +397,34 @@ void MonomeSerialDevice::processSerial() {
           readX = Serial.read();                      // led-grid / set LED intensity
           readY = Serial.read();                      // read the x and y coordinates
           intensity = Serial.read();                  // read the intensity
-          setGridLed(readX, readY, intensity);              
+          setGridLed(readX, readY, intensity);
           break;
 
         case 0x19:                               //  /prefix/led/level/all s
           intensity = Serial.read();                 // set all leds
-          setAllLEDs(intensity);              
+          setAllLEDs(intensity);
           break;
 
         case 0x1A:                               //   /prefix/led/level/map x y d[64]
-                                                 // set 8x8 block          
+                                                 // set 8x8 block
           readX = Serial.read();                      // x offset
           while (readX > 16) { readX += 16; }         // hacky shit to deal with negative numbers from rotation
           readX &= 0xF8;                              // floor the offset to 0 or 8
           readY = Serial.read();                      // y offset
           while (readY > 16) { readY += 16; }         // hacky shit to deal with negative numbers from rotation
           readY &= 0xF8;                              // floor the offset to 0 or 8
-          
+
           z = 0;
           for (y = 0; y < 8; y++) {
             for (x = 0; x < 8; x++) {
-              if (z % 2 == 0) {                    
+              if (z % 2 == 0) {
                 intensity = Serial.read();
                 if ( ((intensity >> 4) & 0x0F) > variMonoThresh) {  // even bytes, use upper nybble
                   setGridLed(readX + x, readY + y, (intensity >> 4) & 0x0F);
                 } else {
                   setGridLed(readX + x, readY + y, 0);
                 }
-              } else { 
+              } else {
                 if ((intensity & 0x0F) > variMonoThresh ) {      // odd bytes, use lower nybble
                   setGridLed(readX + x, readY + y, intensity & 0x0F);
                 } else {
@@ -450,7 +450,7 @@ void MonomeSerialDevice::processSerial() {
           while (readY > 16) { readY += 16; }         // hacky shit to deal with negative numbers from rotation
           readY &= 0xF8;                              // floor the offset to 0 or 8
           for (x = 0; x < 8; x++) {
-              if (x % 2 == 0) {                    
+              if (x % 2 == 0) {
                 intensity = Serial.read();
                 if ( (intensity >> 4 & 0x0F) > variMonoThresh) {  // even bytes, use upper nybble
                   setGridLed(readX + x, readY, (intensity >> 4) & 0x0F);
@@ -458,7 +458,7 @@ void MonomeSerialDevice::processSerial() {
                 else {
                   setGridLed(readX + x, readY, 0);
                 }
-              } else {                              
+              } else {
                 if ((intensity & 0x0F) > variMonoThresh ) {      // odd bytes, use lower nybble
                   setGridLed(readX + x, readY, intensity & 0x0F);
                 }
@@ -477,7 +477,7 @@ void MonomeSerialDevice::processSerial() {
           while (readY > 16) { readY += 16; }         // hacky shit to deal with negative numbers from rotation
           readY &= 0xF8;                              // floor the offset to 0 or 8
           for (y = 0; y < 8; y++) {
-              if (y % 2 == 0) {                    
+              if (y % 2 == 0) {
                 intensity = Serial.read();
                 if ( (intensity >> 4 & 0x0F) > variMonoThresh) {  // even bytes, use upper nybble
                   setGridLed(readX, readY + y, (intensity >> 4) & 0x0F);
@@ -485,7 +485,7 @@ void MonomeSerialDevice::processSerial() {
                 else {
                   setGridLed(readX, readY + y, 0);
                 }
-              } else {                              
+              } else {
                 if ((intensity & 0x0F) > variMonoThresh ) {      // odd bytes, use lower nybble
                   setGridLed(readX, readY + y, intensity & 0x0F);
                 }
@@ -519,7 +519,7 @@ void MonomeSerialDevice::processSerial() {
             Serial.print(" up - ");
             */
             break;
-            
+
         case 0x21:
             /*
              0x21 key-grid / key down
@@ -596,7 +596,7 @@ void MonomeSerialDevice::processSerial() {
         case 0x81:  //   tilt - 8 bytes [0x80, n, xh, xl, yh, yl, zh, zl]
             break;
 
-        // 0x90 variable 64 LED ring 
+        // 0x90 variable 64 LED ring
         case 0x90:
           //pattern:  /prefix/ring/set n x a
           //desc:   set led x of ring n to value a
@@ -608,9 +608,9 @@ void MonomeSerialDevice::processSerial() {
           readX = Serial.read();
           readA = Serial.read();
           //led_array[readN][readX] = readA;
-          setArcLed(readN, readX, readA);         
+          setArcLed(readN, readX, readA);
           break;
-     
+
         case 0x91:
           //pattern:  /prefix/ring/all n a
           //desc:   set all leds of ring n to a
@@ -624,7 +624,7 @@ void MonomeSerialDevice::processSerial() {
             //led_array[readN][q]=readA;
           }
           break;
-      
+
         case 0x92:
           //pattern:  /prefix/ring/map n d[32]
           //desc:   set leds of ring n to array d
@@ -639,17 +639,17 @@ void MonomeSerialDevice::processSerial() {
           //serial:   [0x92, n d[32]]
           readN = Serial.read();
           for (y = 0; y < 64; y++) {
-              if (y % 2 == 0) {                    
+              if (y % 2 == 0) {
                 intensity = Serial.read();
                 if ( (intensity >> 4 & 0x0F) > 0) {  // even bytes, use upper nybble
                   //led_array[readN][y] = (intensity >> 4 & 0x0F);
-                  setArcLed(readN, y, (intensity >> 4 & 0x0F)); 
+                  setArcLed(readN, y, (intensity >> 4 & 0x0F));
                 }
                 else {
                   //led_array[readN][y]=0;
-                  setArcLed(readN, y, 0);   
+                  setArcLed(readN, y, 0);
                 }
-              } else {                              
+              } else {
                 if ((intensity & 0x0F) > 0 ) {      // odd bytes, use lower nybble
                   //led_array[readN][y] = (intensity & 0x0F);
                   setArcLed(readN, y, (intensity & 0x0F));
@@ -675,7 +675,7 @@ void MonomeSerialDevice::processSerial() {
           readY = Serial.read();  // x2
           readA = Serial.read();
           //memset(led_array[readN],0,sizeof(led_array[readN]));
-      
+
           if (readX < readY){
             for (y = readX; y < readY; y++) {
               //led_array[readN][y] = readA;
@@ -692,11 +692,18 @@ void MonomeSerialDevice::processSerial() {
               setArcLed(readN, y, readA);
             }
           }
-          //note:   set range x1-x2 (inclusive) to a. wrapping supported, ie. set range 60,4 would set values 60,61,62,63,0,1,2,3,4. 
-          // always positive direction sweep. ie. 4,10 = 4,5,6,7,8,9,10 whereas 10,4 = 10,11,12,13...63,0,1,2,3,4 
+          //note:   set range x1-x2 (inclusive) to a. wrapping supported, ie. set range 60,4 would set values 60,61,62,63,0,1,2,3,4.
+          // always positive direction sweep. ie. 4,10 = 4,5,6,7,8,9,10 whereas 10,4 = 10,11,12,13...63,0,1,2,3,4
          break;
 
-        default: 
+        case 0xF9:
+            R = Serial.read();
+            G = Serial.read();
+            B = Serial.read();
+            colorDirty = true;
+         break;
+
+        default:
           break;
     }
 }
@@ -779,7 +786,7 @@ void MonomeEventQueue::sendArcKey(uint8_t index, uint8_t pressed) {
     Serial.write(buf, 2);
 }
 
-void MonomeEventQueue::sendGridKey(uint8_t x, uint8_t y, uint8_t pressed) {    
+void MonomeEventQueue::sendGridKey(uint8_t x, uint8_t y, uint8_t pressed) {
     uint8_t buf[2];
     if (pressed == 1){
       buf[0] = 0x21;

--- a/neotrellis_monome_rp2040/MonomeSerialDevice.h
+++ b/neotrellis_monome_rp2040/MonomeSerialDevice.h
@@ -19,7 +19,7 @@ class MonomeArcEvent {
 class MonomeEventQueue {
     public:
         //void clearQueue();
-        
+
         bool gridEventAvailable();
         MonomeGridEvent readGridEvent();
         MonomeGridEvent sendGridKey();
@@ -28,7 +28,7 @@ class MonomeEventQueue {
         MonomeArcEvent readArcEvent();
         MonomeArcEvent sendArcDelta();
         MonomeArcEvent sendArcKey();
-       
+
         void addGridEvent(uint8_t x, uint8_t y, uint8_t pressed);
         void sendGridKey(uint8_t x, uint8_t y, uint8_t pressed);
         void addArcEvent(uint8_t index, int8_t delta);
@@ -37,10 +37,10 @@ class MonomeEventQueue {
         void sendTiltEvent(uint8_t n,uint8_t xh,uint8_t xl, uint8_t yh,uint8_t yl, uint8_t zh,uint8_t zl);
 
     protected:
-        
+
     private:
         static const int MAXEVENTCOUNT = 50;
-        
+
         MonomeGridEvent emptyGridEvent;
         MonomeGridEvent gridEvents[MAXEVENTCOUNT];
         int gridEventCount = 0;
@@ -53,7 +53,7 @@ class MonomeEventQueue {
 };
 
 class MonomeSerialDevice : public MonomeEventQueue {
-    public: 
+    public:
         MonomeSerialDevice();
         void initialize();
         void setupAsGrid(uint8_t _rows, uint8_t _columns);
@@ -85,11 +85,16 @@ class MonomeSerialDevice : public MonomeEventQueue {
         static const int MAXLEDCOUNT = 256;
         uint8_t leds[MAXLEDCOUNT];
         String deviceID;
-        
-    private : 
+
+        uint8_t R = 255;
+        uint8_t G = 255;
+        uint8_t B = 255;
+        bool colorDirty = false;
+
+    private :
         bool arcDirty = false;
         bool gridDirty = false;
-        
+
 //        MonomeSerialDevice();
         void processSerial();
 };

--- a/neotrellis_monome_teensy/MonomeSerialDevice.cpp
+++ b/neotrellis_monome_teensy/MonomeSerialDevice.cpp
@@ -56,7 +56,7 @@ void MonomeSerialDevice::setAllLEDs(int value) {
 }
 
 void MonomeSerialDevice::setGridLed(uint8_t x, uint8_t y, uint8_t level) {
-//    int index = x + (y * columns);   
+//    int index = x + (y * columns);
 //    if (index < MAXLEDCOUNT) leds[index] = level;
 
     if (x < columns && y < rows) {
@@ -65,7 +65,7 @@ void MonomeSerialDevice::setGridLed(uint8_t x, uint8_t y, uint8_t level) {
     }
     //debugfln(INFO, "LED index: %d x %d y %d", index, x, y);
 }
-        
+
 void MonomeSerialDevice::clearGridLed(uint8_t x, uint8_t y) {
     setGridLed(x, y, 0);
     //Serial.println("clearGridLed");
@@ -76,7 +76,7 @@ void MonomeSerialDevice::setArcLed(uint8_t enc, uint8_t led, uint8_t level) {
     if (index < MAXLEDCOUNT) leds[index] = level;
     //Serial.println("setArcLed");
 }
-        
+
 void MonomeSerialDevice::clearArcLed(uint8_t enc, uint8_t led) {
     setArcLed(enc, led, 0);
     //Serial.println("clearArcLed");
@@ -120,7 +120,7 @@ void MonomeSerialDevice::refresh() {
                 buf[ind++] = (leds[led] << 4) | leds[led + 1];
             }
         Serial.write(buf, 35);
-        
+
         ind = 3;
         buf[1] = 8;
         for (int y = 0; y < 8; y++)
@@ -129,7 +129,7 @@ void MonomeSerialDevice::refresh() {
                 buf[ind++] = (leds[led] << 4) | leds[led + 1];
             }
         Serial.write(buf, 35);
-        
+
         ind = 3;
         buf[1] = 0;
         buf[2] = 8;
@@ -148,7 +148,7 @@ void MonomeSerialDevice::refresh() {
                 buf[ind++] = (leds[led] << 4) | leds[led + 1];
             }
         Serial.write(buf, 35);
-        
+
         gridDirty = false;
     }
 
@@ -161,7 +161,7 @@ void MonomeSerialDevice::refresh() {
         for (led = 0; led < 64; led += 2)
             buf[ind++] = (leds[led] << 4) | leds[led + 1];
         Serial.write(buf, 34);
-        
+
         buf[1] = 1;
         ind = 2;
         for (led = 64; led < 128; led += 2)
@@ -173,13 +173,13 @@ void MonomeSerialDevice::refresh() {
         for (led = 128; led < 192; led += 2)
             buf[ind++] = (leds[led] << 4) | leds[led + 1];
         Serial.write(buf, 34);
-        
+
         buf[1] = 3;
         ind = 2;
         for (led = 192; led < 256; led += 2)
             buf[ind++] = (leds[led] << 4) | leds[led + 1];
         Serial.write(buf, 34);
-        
+
         buf[1] = 4;
         ind = 2;
         for (led = 256; led < 320; led += 2)
@@ -221,13 +221,13 @@ void MonomeSerialDevice::processSerial() {
     uint8_t gridX    = columns;          // Will be either 8 or 16
     uint8_t gridY    = rows;
     uint8_t numQuads = columns/rows;
-    
+
     // get command identifier: first byte of packet is identifier in the form: [(a << 4) + b]
     // a = section (ie. system, key-grid, digital, encoder, led grid, tilt)
     // b = command (ie. query, enable, led, key, frame)
 
-    identifierSent = Serial.read();  
-    
+    identifierSent = Serial.read();
+
     switch (identifierSent) {
         case 0x00:  // device information
         	// [null, "led-grid", "key-grid", "digital-out", "digital-in", "encoder", "analog-in", "analog-out", "tilt", "led-ring"]
@@ -237,8 +237,8 @@ void MonomeSerialDevice::processSerial() {
             Serial.write((uint8_t)numQuads);   // one Quad is 64 buttons
 
             Serial.write((uint8_t)0x00); // send again with 2 = key-grid
-            Serial.write((uint8_t)0x02); // 
-            Serial.write((uint8_t)numQuads); 
+            Serial.write((uint8_t)0x02); //
+            Serial.write((uint8_t)numQuads);
 
             break;
 
@@ -272,7 +272,7 @@ void MonomeSerialDevice::processSerial() {
             //Serial.println("0x04");
             gridNum = Serial.read();        // grid number
             readX = Serial.read();          // x offset
-            readY = Serial.read();          // y offset 
+            readY = Serial.read();          // y offset
             break;
 
         case 0x05:  // _SYS_GET_GRID_SIZE
@@ -305,7 +305,7 @@ void MonomeSerialDevice::processSerial() {
 
 
       // 0x10-0x1F are for an LED Grid Control.  All bytes incoming, no responses back
-  
+
         case 0x10:            // /prefix/led/set x y [0/1]  / led off
           readX = Serial.read();
           readY = Serial.read();
@@ -337,13 +337,13 @@ void MonomeSerialDevice::processSerial() {
 
           for (y = 0; y < 8; y++) {               // each i will be a row
             intensity = Serial.read();            // read one byte of 8 bits on/off
-    
+
             for (x = 0; x < 8; x++) {             // for 8 LEDs on a row
               if ((intensity >> x) & 0x01) {      // if intensity bit set, light led full brightness
-                setGridLed(readX + x, readY + y, 15); 
+                setGridLed(readX + x, readY + y, 15);
               }
               else {
-                setGridLed(readX + x, readY + y, 0); 
+                setGridLed(readX + x, readY + y, 0);
               }
             }
           }
@@ -354,7 +354,7 @@ void MonomeSerialDevice::processSerial() {
           while (readX > 16) { readX += 16; }         // hacky shit to deal with negative numbers from rotation
           readX &= 0xF8;                              // floor the offset to 0 or 8
 
-          readY = Serial.read();                      // 
+          readY = Serial.read();                      //
           intensity = Serial.read();                  // read one byte of 8 bits on/off
 
           for (x = 0; x < 8; x++) {               // for the next 8 lights in row
@@ -397,34 +397,34 @@ void MonomeSerialDevice::processSerial() {
           readX = Serial.read();                      // led-grid / set LED intensity
           readY = Serial.read();                      // read the x and y coordinates
           intensity = Serial.read();                  // read the intensity
-          setGridLed(readX, readY, intensity);              
+          setGridLed(readX, readY, intensity);
           break;
 
         case 0x19:                               //  /prefix/led/level/all s
           intensity = Serial.read();                 // set all leds
-          setAllLEDs(intensity);              
+          setAllLEDs(intensity);
           break;
 
         case 0x1A:                               //   /prefix/led/level/map x y d[64]
-                                                 // set 8x8 block          
+                                                 // set 8x8 block
           readX = Serial.read();                      // x offset
           while (readX > 16) { readX += 16; }         // hacky shit to deal with negative numbers from rotation
           readX &= 0xF8;                              // floor the offset to 0 or 8
           readY = Serial.read();                      // y offset
           while (readY > 16) { readY += 16; }         // hacky shit to deal with negative numbers from rotation
           readY &= 0xF8;                              // floor the offset to 0 or 8
-          
+
           z = 0;
           for (y = 0; y < 8; y++) {
             for (x = 0; x < 8; x++) {
-              if (z % 2 == 0) {                    
+              if (z % 2 == 0) {
                 intensity = Serial.read();
                 if ( ((intensity >> 4) & 0x0F) > variMonoThresh) {  // even bytes, use upper nybble
                   setGridLed(readX + x, readY + y, (intensity >> 4) & 0x0F);
                 } else {
                   setGridLed(readX + x, readY + y, 0);
                 }
-              } else { 
+              } else {
                 if ((intensity & 0x0F) > variMonoThresh ) {      // odd bytes, use lower nybble
                   setGridLed(readX + x, readY + y, intensity & 0x0F);
                 } else {
@@ -450,7 +450,7 @@ void MonomeSerialDevice::processSerial() {
           while (readY > 16) { readY += 16; }         // hacky shit to deal with negative numbers from rotation
 //           readY &= 0xF8;                              // floor the offset to 0 or 8
           for (x = 0; x < 8; x++) {
-              if (x % 2 == 0) {                    
+              if (x % 2 == 0) {
                 intensity = Serial.read();
                 if ( (intensity >> 4 & 0x0F) > variMonoThresh) {  // even bytes, use upper nybble
                   setGridLed(readX + x, readY, (intensity >> 4) & 0x0F);
@@ -458,7 +458,7 @@ void MonomeSerialDevice::processSerial() {
                 else {
                   setGridLed(readX + x, readY, 0);
                 }
-              } else {                              
+              } else {
                 if ((intensity & 0x0F) > variMonoThresh ) {      // odd bytes, use lower nybble
                   setGridLed(readX + x, readY, intensity & 0x0F);
                 }
@@ -477,7 +477,7 @@ void MonomeSerialDevice::processSerial() {
           while (readY > 16) { readY += 16; }         // hacky shit to deal with negative numbers from rotation
           readY &= 0xF8;                              // floor the offset to 0 or 8
           for (y = 0; y < 8; y++) {
-              if (y % 2 == 0) {                    
+              if (y % 2 == 0) {
                 intensity = Serial.read();
                 if ( (intensity >> 4 & 0x0F) > variMonoThresh) {  // even bytes, use upper nybble
                   setGridLed(readX, readY + y, (intensity >> 4) & 0x0F);
@@ -485,7 +485,7 @@ void MonomeSerialDevice::processSerial() {
                 else {
                   setGridLed(readX, readY + y, 0);
                 }
-              } else {                              
+              } else {
                 if ((intensity & 0x0F) > variMonoThresh ) {      // odd bytes, use lower nybble
                   setGridLed(readX, readY + y, intensity & 0x0F);
                 }
@@ -519,7 +519,7 @@ void MonomeSerialDevice::processSerial() {
             Serial.print(" up - ");
             */
             break;
-            
+
         case 0x21:
             /*
              0x21 key-grid / key down
@@ -596,7 +596,7 @@ void MonomeSerialDevice::processSerial() {
         case 0x81:  //   tilt - 8 bytes [0x80, n, xh, xl, yh, yl, zh, zl]
             break;
 
-        // 0x90 variable 64 LED ring 
+        // 0x90 variable 64 LED ring
         case 0x90:
           //pattern:  /prefix/ring/set n x a
           //desc:   set led x of ring n to value a
@@ -608,9 +608,9 @@ void MonomeSerialDevice::processSerial() {
           readX = Serial.read();
           readA = Serial.read();
           //led_array[readN][readX] = readA;
-          setArcLed(readN, readX, readA);         
+          setArcLed(readN, readX, readA);
           break;
-     
+
         case 0x91:
           //pattern:  /prefix/ring/all n a
           //desc:   set all leds of ring n to a
@@ -624,7 +624,7 @@ void MonomeSerialDevice::processSerial() {
             //led_array[readN][q]=readA;
           }
           break;
-      
+
         case 0x92:
           //pattern:  /prefix/ring/map n d[32]
           //desc:   set leds of ring n to array d
@@ -639,17 +639,17 @@ void MonomeSerialDevice::processSerial() {
           //serial:   [0x92, n d[32]]
           readN = Serial.read();
           for (y = 0; y < 64; y++) {
-              if (y % 2 == 0) {                    
+              if (y % 2 == 0) {
                 intensity = Serial.read();
                 if ( (intensity >> 4 & 0x0F) > 0) {  // even bytes, use upper nybble
                   //led_array[readN][y] = (intensity >> 4 & 0x0F);
-                  setArcLed(readN, y, (intensity >> 4 & 0x0F)); 
+                  setArcLed(readN, y, (intensity >> 4 & 0x0F));
                 }
                 else {
                   //led_array[readN][y]=0;
-                  setArcLed(readN, y, 0);   
+                  setArcLed(readN, y, 0);
                 }
-              } else {                              
+              } else {
                 if ((intensity & 0x0F) > 0 ) {      // odd bytes, use lower nybble
                   //led_array[readN][y] = (intensity & 0x0F);
                   setArcLed(readN, y, (intensity & 0x0F));
@@ -675,7 +675,7 @@ void MonomeSerialDevice::processSerial() {
           readY = Serial.read();  // x2
           readA = Serial.read();
           //memset(led_array[readN],0,sizeof(led_array[readN]));
-      
+
           if (readX < readY){
             for (y = readX; y < readY; y++) {
               //led_array[readN][y] = readA;
@@ -692,11 +692,18 @@ void MonomeSerialDevice::processSerial() {
               setArcLed(readN, y, readA);
             }
           }
-          //note:   set range x1-x2 (inclusive) to a. wrapping supported, ie. set range 60,4 would set values 60,61,62,63,0,1,2,3,4. 
-          // always positive direction sweep. ie. 4,10 = 4,5,6,7,8,9,10 whereas 10,4 = 10,11,12,13...63,0,1,2,3,4 
+          //note:   set range x1-x2 (inclusive) to a. wrapping supported, ie. set range 60,4 would set values 60,61,62,63,0,1,2,3,4.
+          // always positive direction sweep. ie. 4,10 = 4,5,6,7,8,9,10 whereas 10,4 = 10,11,12,13...63,0,1,2,3,4
          break;
 
-        default: 
+        case 0xF9:
+            R = Serial.read();
+            G = Serial.read();
+            B = Serial.read();
+            colorDirty = true;
+         break;
+
+        default:
           break;
     }
 }
@@ -779,7 +786,7 @@ void MonomeEventQueue::sendArcKey(uint8_t index, uint8_t pressed) {
     Serial.write(buf, 2);
 }
 
-void MonomeEventQueue::sendGridKey(uint8_t x, uint8_t y, uint8_t pressed) {    
+void MonomeEventQueue::sendGridKey(uint8_t x, uint8_t y, uint8_t pressed) {
     uint8_t buf[2];
     if (pressed == 1){
       buf[0] = 0x21;

--- a/neotrellis_monome_teensy/MonomeSerialDevice.h
+++ b/neotrellis_monome_teensy/MonomeSerialDevice.h
@@ -19,7 +19,7 @@ class MonomeArcEvent {
 class MonomeEventQueue {
     public:
         //void clearQueue();
-        
+
         bool gridEventAvailable();
         MonomeGridEvent readGridEvent();
         MonomeGridEvent sendGridKey();
@@ -28,7 +28,7 @@ class MonomeEventQueue {
         MonomeArcEvent readArcEvent();
         MonomeArcEvent sendArcDelta();
         MonomeArcEvent sendArcKey();
-       
+
         void addGridEvent(uint8_t x, uint8_t y, uint8_t pressed);
         void sendGridKey(uint8_t x, uint8_t y, uint8_t pressed);
         void addArcEvent(uint8_t index, int8_t delta);
@@ -36,10 +36,10 @@ class MonomeEventQueue {
         void sendArcKey(uint8_t index, uint8_t pressed);
 
     protected:
-        
+
     private:
         static const int MAXEVENTCOUNT = 50;
-        
+
         MonomeGridEvent emptyGridEvent;
         MonomeGridEvent gridEvents[MAXEVENTCOUNT];
         int gridEventCount = 0;
@@ -52,7 +52,7 @@ class MonomeEventQueue {
 };
 
 class MonomeSerialDevice : public MonomeEventQueue {
-    public: 
+    public:
         MonomeSerialDevice();
         void initialize();
         void setupAsGrid(uint8_t _rows, uint8_t _columns);
@@ -84,11 +84,16 @@ class MonomeSerialDevice : public MonomeEventQueue {
         static const int MAXLEDCOUNT = 256;
         uint8_t leds[MAXLEDCOUNT];
         String deviceID;
-        
-    private : 
+
+        uint8_t R = 255;
+        uint8_t G = 255;
+        uint8_t B = 255;
+        bool colorDirty = false;
+
+    private :
         bool arcDirty = false;
         bool gridDirty = false;
-        
+
 //        MonomeSerialDevice();
         void processSerial();
 };

--- a/neotrellis_monome_teensy/neotrellis_monome_teensy.ino
+++ b/neotrellis_monome_teensy/neotrellis_monome_teensy.ino
@@ -1,16 +1,16 @@
 /***********************************************************
  *  DIY monome compatible grid w/ Adafruit NeoTrellis
  *  for Teensy
- *  
+ *
  *  This code makes the Adafruit Neotrellis boards into a Monome compatible grid via monome's mext protocol
  *  ----> https://www.adafruit.com/product/3954
- *  
+ *
  *  Code here is for a 16x8 grid, but can be modified for 4x8, 8x8, or 16x16 (untested on larger grid arrays)
- *  
- *  Many thanks to: 
- *  scanner_darkly <https://github.com/scanner-darkly>, 
- *  TheKitty <https://github.com/TheKitty>, 
- *  Szymon Kaliski <https://github.com/szymonkaliski>, 
+ *
+ *  Many thanks to:
+ *  scanner_darkly <https://github.com/scanner-darkly>,
+ *  TheKitty <https://github.com/TheKitty>,
+ *  Szymon Kaliski <https://github.com/szymonkaliski>,
  *  John Park, Todbot, Juanma, Gerald Stevens, and others
  *
 */
@@ -23,22 +23,22 @@
 #define NUM_COLS 16 // DIM_X number of columns of keys across
 
 #define INT_PIN 9
-#define LED_PIN 13 // teensy LED 
+#define LED_PIN 13 // teensy LED
 
-// This assumes you are using a USB breakout board to route power to the board 
+// This assumes you are using a USB breakout board to route power to the board
 // If you are plugging directly into the teensy, you will need to adjust this brightness to a much lower value
 #define BRIGHTNESS 255 // overall grid brightness - use gamma table below to adjust levels
 
 // RGB values - vary for colors other than white
-#define R 255
-#define G 255
-#define B 255
+#define DEFAULT_R 255
+#define DEFAULT_G 255
+#define DEFAULT_B 255
 //  amber-ish {255,191,0}
 //  warmer white? {255,255,200}
 
 // Gamma table to customize 16 levels of brightness
 // RGB values above will be scaled to these
-const uint8_t gammaTable[16] = { 2,  3,  4,  6,  11, 18, 25, 32, 41, 59, 70, 80, 92, 103, 115, 128}; 
+const uint8_t gammaTable[16] = { 2,  3,  4,  6,  11, 18, 25, 32, 41, 59, 70, 80, 92, 103, 115, 128};
 
 
 bool isInited = false;
@@ -50,7 +50,7 @@ String deviceID = "neo-monome";
 // Monome class setup
 MonomeSerialDevice mdp;
 
-int prevLedBuffer[mdp.MAXLEDCOUNT]; 
+int prevLedBuffer[mdp.MAXLEDCOUNT];
 
 
 // NeoTrellis setup
@@ -61,7 +61,7 @@ Adafruit_NeoTrellis trellis_array[NUM_ROWS / 4][NUM_COLS / 4] = {
   { Adafruit_NeoTrellis(0x3E), Adafruit_NeoTrellis(0x36) }
 };
 */
-// 16x8 
+// 16x8
 Adafruit_NeoTrellis trellis_array[NUM_ROWS / 4][NUM_COLS / 4] = {
   { Adafruit_NeoTrellis(0x32), Adafruit_NeoTrellis(0x30), Adafruit_NeoTrellis(0x2F), Adafruit_NeoTrellis(0x2E) }, // top row
   { Adafruit_NeoTrellis(0x33), Adafruit_NeoTrellis(0x31), Adafruit_NeoTrellis(0x3E), Adafruit_NeoTrellis(0x36) } // bottom row
@@ -72,8 +72,8 @@ Adafruit_NeoTrellis trellis_array[NUM_ROWS / 4][NUM_COLS / 4] = {
 Adafruit_NeoTrellis trellis_array[NUM_ROWS / 4][NUM_COLS / 4] = {
   { Adafruit_NeoTrellis(0x33), Adafruit_NeoTrellis(0x31), Adafruit_NeoTrellis(0x2F), Adafruit_NeoTrellis(0x2E)}, // top row
   { Adafruit_NeoTrellis(0x35), Adafruit_NeoTrellis(0x39), Adafruit_NeoTrellis(0x3F), Adafruit_NeoTrellis(0x37)}, // bottom row
-  { Adafruit_NeoTrellis(0x43), Adafruit_NeoTrellis(0x41), Adafruit_NeoTrellis(0x36), Adafruit_NeoTrellis(0x3E)}, 
-  { Adafruit_NeoTrellis(0x45), Adafruit_NeoTrellis(0x49), Adafruit_NeoTrellis(0x4d), Adafruit_NeoTrellis(0x47)} 
+  { Adafruit_NeoTrellis(0x43), Adafruit_NeoTrellis(0x41), Adafruit_NeoTrellis(0x36), Adafruit_NeoTrellis(0x3E)},
+  { Adafruit_NeoTrellis(0x45), Adafruit_NeoTrellis(0x49), Adafruit_NeoTrellis(0x4d), Adafruit_NeoTrellis(0x47)}
 };
 */
 
@@ -109,7 +109,7 @@ uint32_t Wheel(byte WheelPos) {
 }
 
 // ***************************************************************************
-// **                          FUNCTIONS FOR TRELLIS                        **   
+// **                          FUNCTIONS FOR TRELLIS                        **
 // ***************************************************************************
 
 
@@ -117,14 +117,14 @@ uint32_t Wheel(byte WheelPos) {
 TrellisCallback keyCallback(keyEvent evt){
 	uint8_t x;
 	uint8_t y;
-	x  = evt.bit.NUM % NUM_COLS; // NUM_COLS; 
-	y = evt.bit.NUM / NUM_COLS; // NUM_COLS; 
+	x  = evt.bit.NUM % NUM_COLS; // NUM_COLS;
+	y = evt.bit.NUM / NUM_COLS; // NUM_COLS;
 	if(evt.bit.EDGE == SEESAW_KEYPAD_EDGE_RISING){
 		//on
 		//Serial.println(" pressed ");
 		mdp.sendGridKey(x, y, 1);
 	}else if(evt.bit.EDGE == SEESAW_KEYPAD_EDGE_FALLING){
-		//off 
+		//off
 		//Serial.println(" released ");
 		mdp.sendGridKey(x, y, 0);
 	}
@@ -143,6 +143,9 @@ void setup(){
   mdp.isMonome = true;
   mdp.deviceID = deviceID;
   mdp.setupAsGrid(NUM_ROWS, NUM_COLS);
+  mdp.R = DEFAULT_R;
+  mdp.G = DEFAULT_G;
+  mdp.B = DEFAULT_B;
   monomeRefresh = 0;
   isInited = true;
 
@@ -168,7 +171,7 @@ void setup(){
 		  trellis.registerCallback(x, y, keyCallback);
 		}
 	}
-  
+
   // set overall brightness for all pixels
   for (x = 0; x < NUM_COLS / 4; x++) {
     for (y = 0; y < NUM_ROWS / 4; y++) {
@@ -181,7 +184,7 @@ void setup(){
   mdp.setAllLEDs(0);
   sendLeds();
 
-  // Blink one led to show it's started up  
+  // Blink one led to show it's started up
   trellis.setPixelColor(0, 0xFFFFFF);
   trellis.show();
   delay(100);
@@ -198,23 +201,24 @@ void sendLeds(){
   uint32_t hexColor;
   bool isDirty = false;
 
-  for(int i=0; i< NUM_ROWS * NUM_COLS; i++){ 
+  for(int i=0; i< NUM_ROWS * NUM_COLS; i++){
     value = mdp.leds[i];
     prevValue = prevLedBuffer[i];
     uint8_t gvalue = gammaTable[value];
 
-    if (value != prevValue) {
-      //hexColor = (((R * value) >> 4) << 16) + (((G * value) >> 4) << 8) + ((B * value) >> 4);
-      hexColor =  (((gvalue*R)/256) << 16) + (((gvalue*G)/256) << 8) + (((gvalue*B)/256) << 0);
+    if (value != prevValue || mdp.colorDirty) {
+      //hexColor = (((mdp.R * value) >> 4) << 16) + (((mdp.G * value) >> 4) << 8) + ((mdp.B * value) >> 4);
+      hexColor =  (((gvalue*mdp.R)/256) << 16) + (((gvalue*mdp.G)/256) << 8) + (((gvalue*mdp.B)/256) << 0);
       trellis.setPixelColor(i, hexColor);
 
       prevLedBuffer[i] = value;
       isDirty = true;
     }
   }
- 
+
   if (isDirty) {
     trellis.show();
+    mdp.colorDirty = false;
   }
 }
 
@@ -227,7 +231,7 @@ void sendLeds(){
 void loop() {
 
     mdp.poll(); // process incoming serial from Monomes
- 
+
     // refresh every 16ms or so
     if (isInited && monomeRefresh > 16) {
         trellis.read();


### PR DESCRIPTION
## client script

[here is a lil norns script](https://github.com/p3r7/neomonome) that calls this newly exposed tint update API. each encoder allows setting R/G/B.

## address

NB: this version still uses a new range of `address` `0xFx`.

as discussed, a alternative would be to use a range unused for grids (e.g. the `0x5x` encoder) instead.

if changing the address, one would also need to patch [these values](https://github.com/p3r7/neomonome/blob/main/src/neomonome.c#L36-L43) in this client script.

## other APIs

should we have other complimentary APIs:
- to query the current tint value?
- to reset to the default value?
- to change the gamma values? 
- to change each level color ("paletted mode")?


## weird behavior w/ some tint values

with some R/G/B value combinations, i was surprised to see a sort of palette appear.

e.g. when trying to go w/ the "warm white" of recent grids 255 / 156 / 92, the lowest levels appear red and yellow-green.

idk if it's a bug w/ how the tint/gamma calculations are made or  if that's "just how gamma works".

if the later, that would encourage to be able to set each level color & gamma separately to guarantee a similar tint accross the whole range of levels.